### PR TITLE
Removed hyphon from requirements

### DIFF
--- a/_docs/session-id.md
+++ b/_docs/session-id.md
@@ -45,7 +45,7 @@ Whether you let Kount generate your session ID, or you generate your own, it'll 
 
 ## Session ID Requirements
 * Session IDs must be unique per request. They must be unique for a minimum of 30 days.
-* Session ID must contain only alphanumeric characters (0-9, a-z or A-Z), dashes (-) or underscores (_).
+* Session ID must contain only alphanumeric characters (0-9, a-z or A-Z), or underscores (_).
 * Session ID values should be 32 characters in length. Session ID values of less than 32 characters
 will be accepted, but it is strongly recommended to use a 32 character value.
 


### PR DESCRIPTION
Removed the hyphon (-) from the Session ID Requirement parameters.